### PR TITLE
Add codesandbox config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The plugin comes with two layouts - Grid and List which are designed carefully a
 
 **[Visit website - wpjobopenings.com](https://wpjobopenings.com/)**
 
+**[Open in CodeSandbox](https://githubbox.com/awsmin/frontity-wp-job-openings)**
+
 ## Installation Requirements
 
 - [Frontity installation requirements](https://docs.frontity.org/getting-started#installation-requirements)

--- a/sandbox.config.json
+++ b/sandbox.config.json
@@ -1,0 +1,3 @@
+{
+  "template": "node"
+}


### PR DESCRIPTION
Now that the repo is a Frontity project, you can use [Codesandbox](https://codesandbox.io), which is a great way for people to quickly take a look at the code, do tests and even modify it to reproduce a bug.

The only thing needed for Frontity projects is this `sandbox.config.js` file. Then, any GitHub URL can start a codesandbox just by replacing the `github.com` domain for `githubbox.com`. For example:

- From https://github.com/luisherranz/frontity-wp-job-openings/tree/codesandbox
- To https://githubbox.com/luisherranz/frontity-wp-job-openings/tree/codesandbox

Once this PR is merged, people can use https://githubbox.com/awsmin/frontity-wp-job-openings to start a codesandbox, then fork it if they need to make modifications.